### PR TITLE
Improve signal handling in PgJobs.work

### DIFF
--- a/app/models/pg_job.rb
+++ b/app/models/pg_job.rb
@@ -42,22 +42,15 @@ class PgJob < ActiveRecord::Base
   #
   # @param queue_name [String] The name of the queue to work on
   # @param timeout [integer] Interval to check for due jobs
-  # @param exit_proc [proc] Proc for graceful exit. This method
-  #   will return between jobs when this proc returns a truthy value.
-  def self.yield_jobs(queue_name, timeout, exit_proc = nil, &block)
+  def self.yield_jobs(queue_name, timeout, &block)
     connection.execute "LISTEN pg_jobs_#{queue_name}"
     loop do
       # Consume all pending NOTIFY events
       while connection.raw_connection.notifies; end
       # Work jobs as long as there are pending jobs in the queue
-      # and the exit_proc does not return a truthy value
-      while yield_job(queue_name, &block)
-        return if exit_proc&.()
-      end
+      while yield_job(queue_name, &block); end
       # Wait for next NOTIFY event
       connection.raw_connection.wait_for_notify(timeout)
-      # Check exit_proc again between wait_for_notify and next job execution
-      return if exit_proc&.()
     end
   ensure
     connection.execute "UNLISTEN pg_jobs_#{queue_name}"

--- a/lib/pg_jobs.rb
+++ b/lib/pg_jobs.rb
@@ -38,14 +38,24 @@ module PgJobs
   # @param exit_signals [Array<String>] Array of signal names for graceful exit
   def self.work(queue_name = 'default', timeout: 10, exit_signals: %w[INT TERM])
     exit_signal = false
+    job_running = false
+
     exit_signals.each do |signal|
       Signal.trap(signal) do
+        raise SignalException, signal unless job_running
+
+        # Put this message to STDERR because the logger cannot be used in a trap context
+        STDERR.puts "Received signal #{signal}, waiting for current job to finish"
         exit_signal = true
       end
     end
 
-    PgJob.yield_jobs(queue_name, timeout, -> { exit_signal }) do |pg_job|
+    PgJob.yield_jobs(queue_name, timeout) do |pg_job|
+      job_running = true
       execute_job(pg_job)
+      job_running = false
+
+      break if exit_signal
     end
   end
 


### PR DESCRIPTION
* Replace exit_proc stuff with a simple `break`. (I feel so stupid
  now...)
* Raise an exception for immediate exit if no job is running so we don't
  need to wait for the `wait_for_notify` timeout.
* Add a message to STDERR when waiting for a job to finish. (Logging is
  not available in a trap context.)